### PR TITLE
Add `builder-init` template support.

### DIFF
--- a/.eslintrc-server-test
+++ b/.eslintrc-server-test
@@ -1,0 +1,14 @@
+---
+extends:
+  - "defaults/configurations/walmart/es5-node"
+
+env:
+  mocha: true
+
+globals:
+  expect: false
+  sandbox: false
+
+rules:
+  no-unused-expressions: 0  # Disable for Chai expression assertions.
+  max-nested-callbacks: 0   # Disable for nested describes.

--- a/.istanbul.server.yml
+++ b/.istanbul.server.yml
@@ -1,0 +1,6 @@
+reporting:
+  dir: coverage/server
+  reports:
+    - lcov
+    - json
+    - text-summary

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+language: node_js
+
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4.2"
+  - "5.0"
+
+# Use container-based Travis infrastructure.
+sudo: false
+
+branches:
+  only:
+    - master
+
+env:
+  matrix:
+    - NPM_3=true
+    - NPM_3=false
+
+before_install:
+  # GUI for real browsers.
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+  # Potentially update to npm 3
+  - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
+
+script:
+  - npm --version
+  - npm run builder:check-ci
+
+  # Manually send coverage reports to coveralls.
+  # - Aggregate client results
+  # - Single server and func test results
+  - ls  coverage/server/lcov.info | cat
+  - cat coverage/server/lcov.info | node_modules/.bin/coveralls || echo "Coveralls upload failed"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Travis Status][trav_img]][trav_site]
+[![Coverage Status][cov_img]][cov_site]
 
 Builder Initializer
 ===================
@@ -18,8 +19,88 @@ from scratch, so you have to start somewhere...
 
 ## Usage
 
-TODO: Add usage.
+```
+TODO: Add usage, documentation.
+https://github.com/FormidableLabs/builder-init/issues/6
+```
+
+
+## Templates
+
+### Application
+
+Presently, _all_ files in the `init/` directory of an archetype are parsed as
+templates. We will reconsider this over time if escaping the template syntax
+becomes problematic.
+
+### Template Parsing
+
+`builder-init` uses Lodash templates, with the following customizations:
+
+* ERB-style templates are the only supported format. The new ES-style template
+  strings are disabled because the underlying processed code is likely to
+  include JS code with ES templates.
+* HTML escaping by default is disabled so that we can easily process `<`, `>`,
+  etc. symbols in JS.
+
+The Lodash templates documentation can be found at:
+https://github.com/lodash/lodash/blob/master/lodash.js#L12302-L12365
+
+And, here's a quick refresher:
+
+**Variables**
+
+```js
+var compiled = _.template("Hi <%= user %>!");
+console.log(compiled({ user: "Bob" }));
+// => "Hi Bob!"
+```
+
+```js
+var compiled = _.template(
+  "Hi <%= _.map(users, function (u) { return u.toUpperCase(); }).join(\", \") %>!");
+console.log(compiled({ users: ["Bob", "Sally"] }));
+// => Hi BOB, SALLY!
+```
+
+**JavaScript Interpolation**
+
+```js
+var compiled = _.template(
+  "Hi <% _.each(users, function (u, i) { %>" +
+    "<%- i === 0 ? '' : ', ' %>" +
+    "<%- u.toUpperCase() %>" +
+  "<% }); %>!");
+console.log(compiled({ users: ["Bob", "Sally"] }));
+// => Hi BOB, SALLY!
+```
+
+### File Name Parsing
+
+In addition file _content_, `builder-init` also interpolates and parses file
+_names_ using an alternate template parsing scheme, inspired by Mustache
+templates. (The rationale for this is that ERB syntax is not file-system
+compliant on all OSes).
+
+So, if we have data: `packageName: "whiz-bang-component"` and want to create
+a file-system path:
+
+```
+src/components/whiz-bang-component.jsx
+```
+
+The source archetype should contain a full file path like:
+
+```
+init/src/components/{{packageName}}.jsx
+```
+
+`builder-init` will validate the expanded file tokens to detect clashes with
+other static file names provided by the generator.
+
 
 [builder]: https://github.com/FormidableLabs/builder
 [trav_img]: https://api.travis-ci.org/FormidableLabs/builder-init.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/builder-init
+[cov_img]: https://img.shields.io/coveralls/FormidableLabs/builder-init.svg
+[cov_site]: https://coveralls.io/r/FormidableLabs/builder-init

--- a/bin/builder-init.js
+++ b/bin/builder-init.js
@@ -1,6 +1,38 @@
 #!/usr/bin/env node
 "use strict";
 
-/*eslint-disable no-console*/
-console.log("TODO CLI builder init");
-/*eslint-enable no-console*/
+var path = require("path");
+var Templates = require("../lib/templates");
+
+// TODO: REMOVE AND IMPLEMENT PROMPTS
+// https://github.com/FormidableLabs/builder-init/issues/3
+var data = {
+  licenseDate: (new Date()).getFullYear(), // DEFAULT
+  licenseOrg: "ACME Corp.", // REQUIRED
+  packageName: "whiz-bang-component", // REQUIRED
+  packageGitHubOrg: "AcmeCorp", // REQUIRED
+  packageDescription: "Whizzically bang React component", // OPTIONAL ("")
+  componentPath: "whiz-bang-component", // DERIVED: packageName
+  componentName: "WhizBangComponent" // DERIVED: pascal(packageName)
+};
+
+// TODO: REMOVE AND IMPLEMENT INSTALL FROM ARCHETYPE
+// https://github.com/FormidableLabs/builder-init/issues/2
+var templates = new Templates({
+  src: path.join(__dirname, "../../builder-react-component/init"),
+  dest: path.join(process.env.HOME, "Desktop/builder-init-temp"),
+  data: data
+});
+
+templates.process(function (err) {
+  // TODO: REAL LOGGING
+  // https://github.com/FormidableLabs/builder-init/issues/4
+  /*eslint-disable no-console*/
+  if (err) {
+    console.error(err);
+  }
+  /*eslint-enable no-console*/
+
+  /*eslint-disable no-process-exit*/
+  process.exit(err ? err.code || 1 : 0);
+});

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -1,0 +1,290 @@
+"use strict";
+
+var path = require("path");
+var _ = require("lodash");
+var async = require("async");
+var fs = require("fs-extra");
+
+// Lodash template setup.
+//
+// HACK: Force ERB style by cloning regexp source. There's a `===` check for
+// "unchanged" that adds in the ES stuff.
+// https://github.com/lodash/lodash/blob/3.6.2-npm-packages/lodash.template/index.js#L26-L27
+_.templateSettings.interpolate = new RegExp(_.templateSettings.interpolate.source);
+// Remove HTML escaping.
+_.templateSettings.escape = null;
+
+/**
+ * Templates wrapper object.
+ *
+ * @param {Object}    opts      Options
+ * @param {String}    opts.src  Template source file path
+ * @param {String}    opts.dest Processed output file path
+ * @param {Object}    opts.data Template data
+ * @returns {void}
+ */
+var Templates = module.exports = function (opts) {
+  opts = opts || {};
+  this.src = opts.src;
+  this.dest = opts.dest;
+  this.data = opts.data || {};
+};
+
+// Curly-brace template regexp for filename parsing.
+Templates.prototype.FILENAME_RE = /\{\{([^\}]+?)\}\}/g;
+
+// Start or end curly special types.
+Templates.prototype.START_END_RE = /\{\{|\}\}/;
+
+/**
+ * Resolve / parse file name into full destination path.
+ *
+ * Uses a very simple curly-brace templating scheme of:
+ *
+ * ```
+ * "{{foo}}.js" -> ({foo: "bar"}) -> "bar.js"
+ * ```
+ *
+ * Notes
+ * - Throws error on unmatched tokens missing in `this.data`.
+ * - Throws error if finds token start / end within matched text.
+ *
+ * @param {String}    dest  File path name or template string
+ * @returns {String}        Resolved file path name
+ */
+Templates.prototype.resolveFilename = function (dest) {
+  if (!dest) { return ""; }
+
+  var self = this;
+  return dest.replace(self.FILENAME_RE, function (raw, token) {
+    if (self.START_END_RE.test(token)) {
+      throw new Error("Forbidden template characters in: '" + token + "' for path: " + dest);
+    }
+
+    var data = self.data[token];
+    if (!data) {
+      throw new Error("Unknown token: '" + token + "' for path: " + dest);
+    }
+
+    return data;
+  });
+};
+
+/**
+ * Read single input file and callback with data object.
+ *
+ * ```js
+ * {
+ *   dest: /OUTPUT/PATH
+ *   content: RAW_STRING_CONTENT
+ * }
+ * ```
+ *
+ * @param {Object}    opts      Options
+ * @param {String}    opts.src  Template source file path
+ * @param {String}    opts.dest Unparsed output file path
+ * @param {Function}  callback  Callback function `(err, data)`
+ * @returns {void}
+ */
+Templates.prototype.readTemplate = function (opts, callback) {
+  fs.readFile(opts.src, function (err, buffer) {
+    callback(err, { dest: opts.dest, content: (buffer || "").toString() });
+  });
+};
+
+/**
+ * Parse and inflate template object with data.
+ *
+ * ```js
+ * {
+ *   dest: /OUTPUT/PATH
+ *   content: PROCESSED_STRING_CONTENT
+ * }
+ * ```
+ *
+ * @param {Object}    opts          Options
+ * @param {String}    opts.dest     Unparsed output file path
+ * @param {String}    opts.content  Unparsed output file contents
+ * @returns {Object}                Processed data object
+ */
+Templates.prototype.processTemplate = function (opts) {
+  // File path: Bespoke {{}} parsing
+  var dest = this.resolveFilename(opts.dest, this.data);
+
+  // Content: Lodash template
+  var compiled = _.template(opts.content.toString());
+  var content = compiled(this.data);
+
+  return { dest: dest, content: content };
+};
+
+/**
+ * Write template file to disk, creating intermediate paths.
+ *
+ * @param {Object}    opts          Options
+ * @param {String}    opts.dest     Processed output file path
+ * @param {String}    opts.content  Processed output file contents
+ * @param {Function}  callback      Callback function `(err)`
+ * @returns {void}
+ */
+Templates.prototype.writeTemplate = function (opts, callback) {
+  async.series([
+    fs.ensureFile.bind(fs, opts.dest),
+    fs.writeFile.bind(fs, opts.dest, opts.content)
+  ], callback);
+};
+
+/**
+ * Statefully load templates. (Does not process templates).
+ *
+ * ```
+ * [
+ *   { dest: "RAW_PATH_01", content: "RAW_CONTENT_01" },
+ *   { dest: "RAW_PATH_02", content: "RAW_CONTENT_02" }
+ * ]
+ * ```
+ *
+ * @param {Function} callback  Callback function `(err, tmpls)`
+ * @returns {void}
+ */
+Templates.prototype.load = function (callback) {
+  var self = this;
+
+  async.auto({
+    // ------------------------------------------------------------------------
+    // Require empty target destination.
+    // ------------------------------------------------------------------------
+    checkEmpty: function (cb) {
+      fs.stat(self.dest, function (err) {
+        if (err) {
+          // Want an empty directory.
+          if (err.code === "ENOENT") {
+            return cb();
+          }
+
+          // Otherwise real error.
+          return cb(err);
+        }
+
+        // Otherwise exists.
+        cb(new Error("Path: " + self.dest + " already exists"));
+      });
+    },
+
+    // ------------------------------------------------------------------------
+    // Walk the entire filesystem tree for the source templates.
+    // ------------------------------------------------------------------------
+    walkTemplates: ["checkEmpty", function (cb) {
+      cb = _.once(cb);
+      var tmpls = [];
+
+      fs.walk(self.src)
+        .on("data", function (item) {
+          if (item.stats.isFile()) {
+            // Only track real files (we'll `mkdir -p` when creating).
+            tmpls.push(item);
+          } else if (!item.stats.isDirectory()) {
+            // Validation: We only handle real files / directories for now.
+            return cb(new Error("Source: " + item.path + " is not a file or directory"));
+          }
+        })
+        .on("error", cb)
+        .on("end", function (err) {
+          return cb(err, tmpls);
+        });
+    }],
+
+    // ------------------------------------------------------------------------
+    // Read source templates and process in memory.
+    // ------------------------------------------------------------------------
+    readTemplates: ["walkTemplates", function (cb, results) {
+      async.map(results.walkTemplates, function (item, tmplCb) {
+        var relPath = path.relative(self.src, item.path);
+        var dest = path.resolve(self.dest, relPath);
+
+        self.readTemplate({
+          src: item.path,
+          dest: dest
+        }, tmplCb);
+      }, cb);
+    }]
+  }, function (err, results) {
+    callback(err, (results || {}).readTemplates);
+  });
+};
+
+/**
+ * Read, process, and write out templates.
+ *
+ * Array of processed template data objects is returned.
+ *
+ * @param {Function} callback  Callback function `(err, data)`
+ * @returns {void}
+ */
+Templates.prototype.process = function (callback) {
+  var self = this;
+
+  async.auto({
+    // ------------------------------------------------------------------------
+    // Load all templates from disk.
+    // ------------------------------------------------------------------------
+    load: self.load.bind(self),
+
+    // ------------------------------------------------------------------------
+    // Process templates in memory.
+    // ------------------------------------------------------------------------
+    procTemplates: ["load", function (cb, results) {
+      var processed;
+
+      try {
+        processed = _.map(results.load, self.processTemplate.bind(self));
+      } catch (err) {
+        return cb(err);
+      }
+
+      cb(null, processed);
+    }],
+
+    // ------------------------------------------------------------------------
+    // Validate processed templates.
+    // ------------------------------------------------------------------------
+    validateTemplates: ["procTemplates", function (cb, results) {
+      var tmpls = results.procTemplates;
+
+      // Check that all paths are unique after template processing.
+      // We're trying to avoid a perverse situation wherein an expanded template
+      // name clashes with a static file path.
+      var nameConflicts = _(tmpls)
+        // Convert to groups of `NAME: COUNT`
+        .groupBy("dest")
+        .mapValues(function (items) { return items.length; })
+        // Switch to `[NAME, COUNT]`
+        .pairs()
+        // Keep only COUNT > 1 (aka "not unique")
+        .filter(function (pair) { return pair[1] > 1; })
+        // Return our offending keys.
+        .map(function (pair) { return pair[0]; })
+        .value();
+
+      var numConflicts = nameConflicts.length;
+      if (numConflicts > 0) {
+        return cb(new Error("Encountered " + numConflicts +
+          " file path conflict" + (numConflicts > 1 ? "s" : "") +
+          " when resolving: " + nameConflicts.join(", ")));
+      }
+
+      // Valid: Just proxy on original templates.
+      cb(null, tmpls);
+    }],
+
+    // ------------------------------------------------------------------------
+    // Write processed templates to disk.
+    // ------------------------------------------------------------------------
+    writeTemplates: ["validateTemplates", function (cb, results) {
+      async.map(results.procTemplates, self.writeTemplate.bind(self), cb);
+    }]
+  }, function (err, results) {
+    // Callback with full processed templates.
+    callback(err, (results || {}).procTemplates);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -17,19 +17,27 @@
   },
   "scripts": {
     "builder:lint-server": "eslint --color -c .eslintrc-server lib bin",
-    "builder:lint": "npm run builder:lint-server",
-    "builder:check": "npm run builder:lint"
+    "builder:lint-server-test": "eslint --color -c .eslintrc-server-test test/server/*.js test/server/spec",
+    "builder:lint": "npm run builder:lint-server && npm run builder:lint-server-test",
+    "builder:test": "mocha --opts test/server/mocha.opts test/server/spec",
+    "builder:test-cov": "istanbul cover --config .istanbul.server.yml  _mocha -- --opts test/server/mocha.opts test/server/spec",
+    "builder:check": "npm run builder:lint && npm run builder:test",
+    "builder:check-ci": "npm run builder:lint && npm run builder:test-cov"
   },
   "dependencies": {
     "async": "^1.5.0",
-    "chalk": "^1.1.1",
     "fs-extra": "^0.26.3",
-    "lodash": "^3.10.1",
-    "nopt": "^3.0.6"
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
+    "chai": "^3.4.1",
+    "coveralls": "^2.11.6",
     "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
-    "eslint-plugin-filenames": "^0.1.2"
+    "eslint-plugin-filenames": "^0.1.2",
+    "istanbul": "^0.4.1",
+    "mocha": "^2.3.4",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/test/server/fixtures/basic/README.md
+++ b/test/server/fixtures/basic/README.md
@@ -1,0 +1,3 @@
+# Basic Tests
+
+These files are to test out basic interpolation for file name and contents.

--- a/test/server/fixtures/basic/src/index.js
+++ b/test/server/fixtures/basic/src/index.js
@@ -1,0 +1,3 @@
+var <%= codeName %> = require("./<%= code %>.js");
+
+module.exports[<%= codeName %>] = <%= codeName %>;

--- a/test/server/fixtures/basic/src/{{code}}.js
+++ b/test/server/fixtures/basic/src/{{code}}.js
@@ -1,0 +1,3 @@
+module.exports = {
+  greeting: "Hello <%= username %>"
+};

--- a/test/server/fixtures/basic/{{text}}.md
+++ b/test/server/fixtures/basic/{{text}}.md
@@ -1,0 +1,1 @@
+<%= username %>'s very own file

--- a/test/server/mocha.opts
+++ b/test/server/mocha.opts
@@ -1,0 +1,2 @@
+--require test/server/setup.js
+--recursive

--- a/test/server/setup.js
+++ b/test/server/setup.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * Test setup for server-side tests.
+ */
+var chai = require("chai");
+var sinonChai = require("sinon-chai");
+
+// Add chai plugins.
+chai.use(sinonChai);
+
+// Add test lib globals.
+global.expect = chai.expect;

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * Base server unit test initialization / global before/after's.
+ *
+ * This file should be `require`'ed by all other test files.
+ *
+ * **Note**: Because there is a global sandbox server unit tests should always
+ * be run in a separate process from other types of tests.
+ */
+var sinon = require("sinon");
+
+before(function () {
+  // Set test environment
+  process.env.NODE_ENV = process.env.NODE_ENV || "test";
+});
+
+beforeEach(function () {
+  global.sandbox = sinon.sandbox.create({
+    useFakeTimers: true
+  });
+});
+
+afterEach(function () {
+  global.sandbox.restore();
+});

--- a/test/server/spec/lib/templates.spec.js
+++ b/test/server/spec/lib/templates.spec.js
@@ -1,0 +1,254 @@
+"use strict";
+
+var path = require("path");
+var _ = require("lodash");
+var Templates = require("../../../../lib/templates");
+
+require("../base.spec");
+
+describe("lib/templates", function () {
+  var basicTemplates;
+  var basicRawTmpls;
+
+  before(function (done) {
+    // File I/O: Do a one-time load of the basic fixtures.
+    // Leave `dest`, `data` empty for later hacking.
+    basicTemplates = new Templates({
+      src: path.join(__dirname, "../../fixtures/basic"),
+      dest: path.join(__dirname, "../../fixtures/basic-dest")
+    });
+    basicTemplates.load(function (err, tmpls) {
+      basicRawTmpls = tmpls;
+      done(err);
+    });
+  });
+
+  afterEach(function () {
+    // Reset data for persistent `basicTemplates` object as tests are allowed
+    // to hack this up.
+    basicTemplates.data = {};
+  });
+
+  describe("#resolveFilename", function () {
+    var resolveFilename;
+
+    before(function () {
+      // Reuse object
+      var instance = new Templates({
+        data: {
+          fruit: "apple",
+          vegetable: "tomato"
+        }
+      });
+      resolveFilename = instance.resolveFilename.bind(instance);
+    });
+
+    it("handles base cases", function () {
+      expect(resolveFilename()).to.equal("");
+      expect(resolveFilename(null)).to.equal("");
+      expect(resolveFilename(undefined)).to.equal("");
+    });
+
+    it("passes through non-template strings", function () {
+      expect(resolveFilename("a")).to.equal("a");
+      expect(resolveFilename("{{}}")).to.equal("{{}}");
+      expect(resolveFilename("{singlecurly}.js")).to.equal("{singlecurly}.js");
+      expect(resolveFilename("foo/bar.txt")).to.equal("foo/bar.txt");
+    });
+
+    it("resolves single tokens", function () {
+      expect(resolveFilename("{{fruit}}.js")).to.equal("apple.js");
+      expect(resolveFilename("foo/{{vegetable}}/bar.txt")).to.equal("foo/tomato/bar.txt");
+    });
+
+    it("resolves multiple tokens", function () {
+      expect(resolveFilename("foo/{{vegetable}}/{{fruit}}.txt")).to.equal("foo/tomato/apple.txt");
+    });
+
+    it("throws error on unmatched tokens", function () {
+      expect(function () {
+        resolveFilename("{{tree}}.js");
+      }).to.throw(/Unknown/);
+      expect(function () {
+        resolveFilename("foo/{{vegetable}}/{{extra}}/{{fruit}}.txt");
+      }).to.throw(/Unknown/);
+    });
+
+    it("throws errors on tokens in tokens", function () {
+      expect(function () {
+        resolveFilename("{{ihaz{{fruit}}}}.js");
+      }).to.throw(/Forbidden/);
+      expect(function () {
+        resolveFilename("{{{{fruit}}}}.js");
+      }).to.throw(/Forbidden/);
+    });
+  });
+
+
+  describe("#processTemplate", function () {
+    var instance;
+    var processTemplate;
+
+    beforeEach(function () {
+      instance = new Templates();
+      processTemplate = instance.processTemplate.bind(instance);
+    });
+
+    it("handles non-parsed content", function () {
+      expect(processTemplate({ dest: "foo", content: "" }))
+        .to.eql({ dest: "foo", content: "" });
+      expect(processTemplate({ dest: "bar/bar", content: "Hi" }))
+        .to.eql({ dest: "bar/bar", content: "Hi" });
+    });
+
+    it("leaves ES template strings untouched", function () {
+      expect(processTemplate({ dest: "foo", content: "var foo = `${bar} yo`;" }))
+        .to.eql({ dest: "foo", content: "var foo = `${bar} yo`;" });
+      expect(processTemplate({ dest: "foo", content: "var foo = { bar: `${bar} yo` };" }))
+        .to.eql({ dest: "foo", content: "var foo = { bar: `${bar} yo` };" });
+    });
+
+    it("parses file content", function () {
+      instance.data = { bar: "42" };
+      expect(processTemplate({ dest: "foo", content: "var foo = <%=bar%>;" }))
+        .to.eql({ dest: "foo", content: "var foo = 42;" });
+      expect(processTemplate({ dest: "foo", content: "var foo = {bar: <%= bar %>};" }))
+        .to.eql({ dest: "foo", content: "var foo = {bar: 42};" });
+    });
+
+    it("parses file names", function () {
+      instance.data = { file: "the-stuffz", bar: "23" };
+      expect(processTemplate({ dest: "{{file}}.js", content: "var foo = <%=bar%>;" }))
+        .to.eql({ dest: "the-stuffz.js", content: "var foo = 23;" });
+      expect(processTemplate({ dest: "{{file}}/bar/{{bar}}.js", content: "HI" }))
+        .to.eql({ dest: "the-stuffz/bar/23.js", content: "HI" });
+    });
+  });
+
+  describe("#process", function () {
+    var process;
+
+    describe("empty templates", function () {
+      var instance;
+
+      beforeEach(function () {
+        instance = new Templates({
+          src: path.join(__dirname, "../../fixtures/nonexistent"),
+          dest: path.join(__dirname, "../../fixtures/nonexistent-dest")
+        });
+        process = instance.process.bind(instance);
+
+        // Ensure no file i/o and reuse already loaded source templates
+        sandbox.stub(instance, "load").yields(null, []);
+        sandbox.stub(instance, "writeTemplate").yields();
+      });
+
+      it("succeeds with no writes", function (done) {
+        process(function (err) {
+          expect(err).to.not.be.ok;
+          expect(instance.writeTemplate).not.to.be.called;
+          done();
+        });
+      });
+    });
+
+    describe("basic fixture", function () {
+      beforeEach(function () {
+        process = basicTemplates.process.bind(basicTemplates);
+
+        // Ensure no file i/o and reuse already loaded source templates
+        sandbox.stub(basicTemplates, "load").yields(null, basicRawTmpls);
+        sandbox.stub(basicTemplates, "writeTemplate").yields(null);
+      });
+
+      it("errors on missing data value", function (done) {
+        // Data is missing `text`.
+        basicTemplates.data = {
+          code: "the-codez",
+          codeName: "TheCodez",
+          username: "Billy"
+        };
+
+        process(function (err) {
+          expect(err)
+            .to.be.ok.and
+            .to.have.property("message").and
+              .to.contain("Unknown").and
+              .to.contain("text");
+
+          done();
+        });
+      });
+
+      it("errors on file name expansion clash", function (done) {
+        // `text` value clashes with real file.
+        basicTemplates.data = {
+          code: "the-codez",
+          codeName: "TheCodez",
+          text: "README",
+          username: "Billy"
+        };
+
+        process(function (err) {
+          expect(err)
+            .to.be.ok.and
+            .to.have.property("message").and
+              .to.contain("Encountered 1 file path conflict").and
+              .to.contain("README");
+
+          done();
+        });
+      });
+
+      it("writes out correct templates", function (done) {
+        // Hack in valid data.
+        basicTemplates.data = {
+          code: "the-codez",
+          codeName: "TheCodez",
+          text: "the-textz",
+          username: "Billy"
+        };
+
+        process(function (err, procTmpls) {
+          expect(err).to.not.be.ok;
+
+          // Wrote 4 files (stubbed).
+          expect(basicTemplates.writeTemplate)
+            .to.be.called.and
+            .to.have.callCount(4);
+
+          // Check the resultant templates.
+          expect(procTmpls).to.have.length(4);
+
+          var procObj = _(procTmpls)
+            .map(function (val) { return [path.relative(__dirname, val.dest), val.content]; })
+            .object()
+            .value();
+
+          var procPaths = _(procObj).keys().sortBy(_.identity).value();
+          expect(procPaths).to.deep.equal([
+            "../../fixtures/basic-dest/README.md",
+            "../../fixtures/basic-dest/src/index.js",
+            "../../fixtures/basic-dest/src/the-codez.js",
+            "../../fixtures/basic-dest/the-textz.md"
+          ]);
+
+          expect(procObj).to.have.property("../../fixtures/basic-dest/README.md").and
+            .to.contain("Basic Tests");
+
+          expect(procObj).to.have.property("../../fixtures/basic-dest/the-textz.md").and
+            .to.contain("Billy");
+
+          expect(procObj).to.have.property("../../fixtures/basic-dest/src/index.js").and
+            .to.contain("TheCodez").and
+            .to.contain("the-codez");
+
+          expect(procObj).to.have.property("../../fixtures/basic-dest/src/the-codez.js").and
+            .to.contain("Billy");
+
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Parallel branch to: https://github.com/FormidableLabs/builder-react-component/compare/builder-init

Parallel PR to: https://github.com/FormidableLabs/builder-react-component/pull/24

* Adds template parsing of both file _names_ and file _contents_.
* Adds unit tests for critical templates processing code.
* Hooks up Travis and Coveralls.
* Start basic documentation (with lots of remaining work).

**Note**: This is _just_ the templates and not the prompts or a fully working `builder-init` workflow. I'm going to plan on just landing infrastructure in `master` and not releasing until `builder-init` fully works to get CI working and have digestible, reviewable chunks along the way...

I'm testing this currently by having a repo setup of:

```
REPOS/PATH/
  builder-init/             # On `builder-init` branch
  builder-react-component/  # On `builder-init` branch
```

Then I run:

```sh
$ rm -rf ~/Desktop/builder-init-temp && time ./bin/builder-init.js
```

And open up an inspect `~/Desktop/builder-init-temp`

/cc @coopy @chaseadamsio @exogen @boygirl @zachhale
