### PR TITLE
Ingest prompted, derived data from archetype/init.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ of the `init.js` object can either be an _array_ or _object_ of inquirer
 [question objects][inq-questions]. For example:
 
 ```js
-module.exports: {
+module.exports = {
   prompts: [
     {
       name: "name",
@@ -70,7 +70,7 @@ module.exports: {
 value for a `prompts` object instead of an array:
 
 ```js
-module.exports: {
+module.exports = {
   prompts: {
     name: {
       message: "What is your name?",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Builder Initializer
 ===================
 
-A project generator for [builder][] archetypes.
+Initialize projects from [builder][] archetypes.
 
 ## Installation
 
@@ -16,6 +16,7 @@ $ npm install -g builder-init
 
 Although we generally disfavor global installs, this tool _creates_ new projects
 from scratch, so you have to start somewhere...
+
 
 ## Usage
 
@@ -33,7 +34,7 @@ Archetypes provide data for template expansion via an `init.js` file in the
 root of the archetype. The structure of the file is:
 
 ```js
-module.exports: {
+module.exports = {
   prompts: // Questions and responses for the user
   derived: // Other fields derived from the data provided by the user
 };

--- a/README.md
+++ b/README.md
@@ -27,6 +27,99 @@ https://github.com/FormidableLabs/builder-init/issues/6
 
 ## Templates
 
+### Archetype Data
+
+Archetypes provide data for template expansion via an `init.js` file in the
+root of the archetype. The structure of the file is:
+
+```js
+module.exports: {
+  prompts: // Questions and responses for the user
+  derived: // Other fields derived from the data provided by the user
+};
+```
+
+#### User Prompts
+
+User prompts and responses are ingested using [inquirer][]. The `prompts` field
+of the `init.js` object can either be an _array_ or _object_ of inquirer
+[question objects][inq-questions]. For example:
+
+```js
+module.exports: {
+  prompts: [
+    {
+      name: "name",
+      message: "What is your name?",
+      validate: function (val) {
+        // Validate functions return `true` if valid.
+        // If invalid, return `false` or an error message.
+        return !!val.trim() || "Must enter a name!";
+      }
+    },
+    {
+      name: "quest",
+      message: "What is your quest?"
+    }
+  ]
+};
+```
+
+`builder-init` provides a short-cut of placing the `name` field as the key
+value for a `prompts` object instead of an array:
+
+```js
+module.exports: {
+  prompts: {
+    name: {
+      message: "What is your name?",
+      validate: function (val) { return !!val.trim() || "Must enter a name!"; }
+    },
+    quest: {
+      message: "What is your quest?"
+    }
+  }
+};
+```
+
+**Note - Async**: Inquirer has some nice features, one of which is enabling
+functions like `validate` to become async by using `this.async()`. For
+example:
+
+```js
+name: {
+  message: "What is your name?",
+  validate: function (val) {
+    var done = this.async();
+
+    // Let's wait a second.
+    setTimeout(function () {
+      done(!!val.trim() || "Must enter a name!")
+    }, 1000);
+  }
+}
+```
+
+#### Derived Data
+
+Archetype authors may not wish to expose _all_ data for user input. Thus,
+`builder-init` supports a simple bespoke scheme for taking the existing user
+data and adding derived fields.
+
+The `derived` field of the `init.js` object is an object of functions with
+the signature:
+
+```js
+derived: {
+  // - `data`     All existing data from user prompts.
+  // - `callback` Callback of form `(error, derivedData)`
+  upperName: function (data, cb) {
+    // Uppercase the existing `name` data.
+    cb(null, data.name.toUpperCase());
+  }
+}
+```
+
 ### Application
 
 Presently, _all_ files in the `init/` directory of an archetype are parsed as
@@ -100,6 +193,8 @@ other static file names provided by the generator.
 
 
 [builder]: https://github.com/FormidableLabs/builder
+[inquirer]: https://github.com/SBoudrias/Inquirer.js
+[inq-questions]: https://github.com/SBoudrias/Inquirer.js#question
 [trav_img]: https://api.travis-ci.org/FormidableLabs/builder-init.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/builder-init
 [cov_img]: https://img.shields.io/coveralls/FormidableLabs/builder-init.svg

--- a/bin/builder-init.js
+++ b/bin/builder-init.js
@@ -2,29 +2,28 @@
 "use strict";
 
 var path = require("path");
+var async = require("async");
+var prompts = require("../lib/prompts");
+var init = require(path.resolve(__dirname, "../../builder-react-component/init.js"));
 var Templates = require("../lib/templates");
-
-// TODO: REMOVE AND IMPLEMENT PROMPTS
-// https://github.com/FormidableLabs/builder-init/issues/3
-var data = {
-  licenseDate: (new Date()).getFullYear(), // DEFAULT
-  licenseOrg: "ACME Corp.", // REQUIRED
-  packageName: "whiz-bang-component", // REQUIRED
-  packageGitHubOrg: "AcmeCorp", // REQUIRED
-  packageDescription: "Whizzically bang React component", // OPTIONAL ("")
-  componentPath: "whiz-bang-component", // DERIVED: packageName
-  componentName: "WhizBangComponent" // DERIVED: pascal(packageName)
-};
 
 // TODO: REMOVE AND IMPLEMENT INSTALL FROM ARCHETYPE
 // https://github.com/FormidableLabs/builder-init/issues/2
-var templates = new Templates({
-  src: path.join(__dirname, "../../builder-react-component/init"),
-  dest: path.join(process.env.HOME, "Desktop/builder-init-temp"),
-  data: data
-});
+async.auto({
+  "prompts": prompts.bind(null, init),
 
-templates.process(function (err) {
+  "templates": ["prompts", function (cb, results) {
+    var data = results.prompts;
+
+    var templates = new Templates({
+      src: path.resolve(__dirname, "../../builder-react-component/init"),
+      dest: path.resolve(process.env.HOME, "Desktop/builder-init-temp"),
+      data: data
+    });
+
+    templates.process(cb);
+  }]
+}, function (err) {
   // TODO: REAL LOGGING
   // https://github.com/FormidableLabs/builder-init/issues/4
   /*eslint-disable no-console*/

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -14,17 +14,18 @@ var inquirer = require("inquirer");
 module.exports = function (init, callback) {
   if (!init) { return callback(new Error("Invalid init object")); }
 
-  // Mutate `prompts` into appropriate format.
+  // Give a default value to allow for empty prompts.
   var prompts = init.prompts || [];
-  if (!_.isArray(prompts)) {
-    if (!_.isObject(prompts)) {
-      return callback(new Error("Invalid prompts type: " + typeof prompts));
-    }
 
-    prompts = _.map(prompts, function (val, key) {
-      return _.extend({ name: key }, val);
-    });
+  // Validate.
+  if (!(_.isArray(prompts) || _.isObject(prompts))) {
+    return callback(new Error("Invalid prompts type: " + typeof prompts));
   }
+
+  // Mutate objects to arrays if needed.
+  prompts = _.isArray(prompts) ? prompts : _.map(prompts, function (val, key) {
+    return _.extend({ name: key }, val);
+  });
 
   // Execute prompts, then derive final data.
   async.auto({

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var _ = require("lodash");
+var async = require("async");
+var inquirer = require("inquirer");
+
+/**
+ * Prompt user for input, validate, and add derived fields to final data object.
+ *
+ * @param {Object}    init      Initialization configuration (`prompts`, `derived`)
+ * @param {Function}  callback  Calls back with `(err, data)`
+ * @returns {void}
+ */
+module.exports = function (init, callback) {
+  if (!init) { return callback(new Error("Invalid init object")); }
+
+  // Mutate `prompts` into appropriate format.
+  var prompts = init.prompts || [];
+  if (!_.isArray(prompts)) {
+    if (!_.isObject(prompts)) {
+      return callback(new Error("Invalid prompts type: " + typeof prompts));
+    }
+
+    prompts = _.map(prompts, function (val, key) {
+      return _.extend({ name: key }, val);
+    });
+  }
+
+  // Execute prompts, then derive final data.
+  async.auto({
+    prompts: function (cb) {
+      // Get user prompts. No error, because will prompt user for new input.
+      inquirer.prompt(prompts, function (data) { cb(null, data); });
+    },
+    derived: ["prompts", function (cb, results) {
+      // Create object of functions bound to user input data and invoke.
+      async.auto(_.mapValues(init.derived, function (transform) {
+        return transform.bind(null, results.prompts);
+      }), cb);
+    }]
+  }, function (err, results) {
+    var data = results ? _.extend({}, results.prompts, results.derived) : null;
+    callback(err, data);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "fs-extra": "^0.26.3",
+    "inquirer": "^0.11.1",
     "lodash": "^3.10.1"
   },
   "devDependencies": {

--- a/test/server/spec/lib/prompts.spec.js
+++ b/test/server/spec/lib/prompts.spec.js
@@ -1,0 +1,204 @@
+"use strict";
+
+var _ = require("lodash");
+var async = require("async");
+var prompts = require("../../../../lib/prompts");
+var Prompt = require("inquirer/lib/prompts/input");
+
+require("../base.spec");
+
+// Helpers
+/**
+ * Invoke `prompts` and callback with _expected_ error object.
+ *
+ * @param {Object}    init      Initialization object
+ * @param {Function}  assertFn  Assertion function on `(err)`
+ * @returns {void}
+ */
+var promptsWithErr = function (init, assertFn) {
+  return function (cb) {
+    prompts(init, function (err) {
+      assertFn(err);
+      cb();
+    });
+  };
+};
+
+/**
+ * Invoke `prompts` and callback with data object, erroring when appropriate.
+ *
+ * @param {Object}    init      Initialization object
+ * @param {Function}  [setupFn] (OPTIONAL) Setup state function
+ * @param {Function}  assertFn  Assertion function on `(data)`
+ * @returns {void}
+ */
+var promptsWithData = function (init, setupFn, assertFn) {
+  var args = _.toArray(arguments);
+
+  // Assert function is last.
+  setupFn = args.length === 3 ? args[1] : _.noop;
+  assertFn = args.length === 3 ? args[2] : args[1];
+
+  return function (cb) {
+    setupFn();
+    prompts(init, function (err, data) {
+      if (err) { return cb(err); }
+      assertFn(data);
+      cb();
+    });
+  };
+};
+
+describe("lib/prompts", function () {
+  var runStub;
+
+  beforeEach(function () {
+    // Intercept all real stdin/stdout.
+    runStub = sandbox.stub(Prompt.prototype, "run");
+  });
+
+  it("errors on invalid init object", function (done) {
+    async.series([
+      promptsWithErr(undefined, function (err) {
+        expect(err)
+          .to.be.an.instanceOf(Error).and
+          .to.have.property("message", "Invalid init object");
+      }),
+      promptsWithErr(null, function (err) {
+        expect(err)
+          .to.be.an.instanceOf(Error).and
+          .to.have.property("message", "Invalid init object");
+      }),
+      promptsWithErr({ prompts: "invalid-string" }, function (err) {
+        expect(err)
+          .to.be.an.instanceOf(Error).and
+          .to.have.property("message").and
+            .to.contain("Invalid prompts type");
+      })
+    ], done);
+  });
+
+  it("handles base cases", function (done) {
+    async.series([
+      promptsWithData({}, function (data) {
+        expect(data).to.deep.equal({});
+      }),
+      promptsWithData({ prompts: [] }, function (data) {
+        expect(data).to.deep.equal({});
+      }),
+      promptsWithData({ prompts: {}, derived: {} }, function (data) {
+        expect(data).to.deep.equal({});
+      })
+    ], done);
+  });
+
+  it("creates derived data alone", function (done) {
+    async.series([
+      promptsWithData({
+        derived: {
+          foo: function (data, cb) { cb(null, "foo"); },
+          bar: function (data, cb) { cb(null, "bar"); }
+        }
+      }, function (data) {
+        expect(data).to.deep.equal({ foo: "foo", bar: "bar" });
+      }),
+      promptsWithData({
+        derived: {
+          deferred: function (data, cb) { _.defer(cb.bind(null, null, "foo")); }
+        }
+      }, function (data) {
+        expect(data).to.deep.equal({ deferred: "foo" });
+      })
+    ], done);
+  });
+
+  it("handles derived data errors", function (done) {
+    runStub.yields("user");
+
+    async.series([
+      promptsWithErr({
+        prompts: {
+          user: { message: "user" }
+        },
+        derived: {
+          foo: function (data, cb) { cb(new Error("Derived Foo")); }
+        }
+      }, function (err) {
+        expect(err)
+          .to.be.an.instanceOf(Error).and
+          .to.have.property("message").and
+            .to.contain("Derived Foo");
+      }),
+      promptsWithErr({
+        derived: {
+          foo: function (data, cb) { cb(null, "foo"); },
+          bar: function (data, cb) { cb(new Error("Derived Bar")); },
+          baz: function (data, cb) { cb(null, "baz"); }
+        }
+      }, function (err) {
+        expect(err)
+          .to.be.an.instanceOf(Error).and
+          .to.have.property("message").and
+            .to.contain("Derived Bar");
+      })
+    ], done);
+  });
+
+  it("creates prompts data alone", function (done) {
+    async.series([
+      promptsWithData({
+        prompts: {
+          licenseDate: { message: "License date", default: "2016" }
+        }
+      }, function () {
+        runStub
+          .reset()
+          .onCall(0).yields("2016");
+      }, function (data) {
+        expect(data).to.deep.equal({ licenseDate: "2016" });
+      }),
+
+      promptsWithData({
+        prompts: {
+          packageName: { message: "Package name" },
+          packageDescription: { message: "Package description" }
+        }
+      }, function () {
+        runStub
+          .reset()
+          .onCall(0).yields("whiz-bang")
+          .onCall(1).yields("The Whiz Bang");
+      }, function (data) {
+        expect(data).to.deep.equal({
+          packageName: "whiz-bang",
+          packageDescription: "The Whiz Bang"
+        });
+      })
+    ], done);
+  });
+
+  it("creates prompts and derived data", function (done) {
+    promptsWithData({
+      prompts: {
+        year: { message: "License year" }
+      },
+      derived: {
+        reverseYear: function (data, cb) {
+          cb(null, data.year.split("").reverse().join(""));
+        },
+        independent: function (data, cb) { cb(null, "independent"); }
+      }
+    }, function () {
+      runStub
+        .reset()
+        .onCall(0).yields("2016");
+    }, function (data) {
+      expect(data).to.deep.equal({
+        year: "2016",
+        reverseYear: "6102",
+        independent: "independent"
+      });
+    })(done);
+  });
+
+});


### PR DESCRIPTION
Fixes #3

Parallel 'builder-react-component' branch: https://github.com/FormidableLabs/builder-react-component/compare/chore-init-prompts

Parallel 'builder-react-component' PR: https://github.com/FormidableLabs/builder-react-component/pull/30

* Use https://github.com/SBoudrias/Inquirer.js for prompt input, validation.
* Add bespoke 'derived' data scheme transforming earlier prompted data.
* Adds unit tests.
* Adds documentation.

/cc @coopy @benbayard @chaseadamsio @exogen @boygirl @zachhale