### PR TITLE
Filter templates w/ .gitignore, switch tests to mock-fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ Presently, _all_ files in the `init/` directory of an archetype are parsed as
 templates. We will reconsider this over time if escaping the template syntax
 becomes problematic.
 
+### Templates Directory Ingestion
+
+`builder-init` mostly just walks the `init/` directory of an archetype looking
+for any files with the following features:
+
+* An empty / non-existent `init/` directory is allowed, although nothing will
+  be written out.
+* If an `init/.gitignore` file is found, the files matched in the templates
+  directory will be filtered to ignore any `.gitignore` glob matches. This
+  filtering is done at _load_ time before file name template strings are
+  expanded (in case that matters).
+
 ### Template Parsing
 
 `builder-init` uses Lodash templates, with the following customizations:

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -4,6 +4,7 @@ var path = require("path");
 var _ = require("lodash");
 var async = require("async");
 var fs = require("fs-extra");
+var ignoreParser = require("gitignore-parser");
 
 // Lodash template setup.
 //
@@ -157,13 +158,8 @@ Templates.prototype.load = function (callback) {
     checkEmpty: function (cb) {
       fs.stat(self.dest, function (err) {
         if (err) {
-          // Want an empty directory.
-          if (err.code === "ENOENT") {
-            return cb();
-          }
-
-          // Otherwise real error.
-          return cb(err);
+          // Proxy all errors except not found.
+          return cb(err.code === "ENOENT" ? null : err);
         }
 
         // Otherwise exists.
@@ -188,17 +184,49 @@ Templates.prototype.load = function (callback) {
             return cb(new Error("Source: " + item.path + " is not a file or directory"));
           }
         })
-        .on("error", cb)
+        .on("error", function (err) {
+          // Proxy all errors except not found with an empty template array.
+          return cb(err.code === "ENOENT" ? null : err, []);
+        })
         .on("end", function (err) {
           return cb(err, tmpls);
         });
     }],
 
     // ------------------------------------------------------------------------
+    // Ingest ignore file and filter.
+    // ------------------------------------------------------------------------
+    loadIgnore: function (cb) {
+      fs.readFile(path.join(self.src, ".gitignore"), function (err, data) {
+        // Process error to allow "not found".
+        err = (err || {}).code === "ENOENT" ? null : err;
+
+        cb(err, data);
+      });
+    },
+
+    filterTemplates: ["walkTemplates", "loadIgnore", function (cb, results) {
+      // Get ignore filter (if any).
+      var ignoreSrc = (results.loadIgnore || "").toString();
+      if (!ignoreSrc) {
+        return cb(null, results.walkTemplates);
+      }
+
+      // Have ignores. Process and filter.
+      var gitignore = ignoreParser.compile(ignoreSrc);
+      var filtered = results.walkTemplates.filter(function (stat) {
+        var relPath = path.relative(self.src, stat.path);
+        return gitignore.accepts(relPath);
+      });
+
+      cb(null, filtered);
+    }],
+
+    // ------------------------------------------------------------------------
     // Read source templates and process in memory.
     // ------------------------------------------------------------------------
-    readTemplates: ["walkTemplates", function (cb, results) {
-      async.map(results.walkTemplates, function (item, tmplCb) {
+    readTemplates: ["filterTemplates", function (cb, results) {
+      async.map(results.filterTemplates, function (item, tmplCb) {
         var relPath = path.relative(self.src, item.path);
         var dest = path.resolve(self.dest, relPath);
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "fs-extra": "^0.26.3",
+    "gitignore-parser": "0.0.2",
     "inquirer": "^0.11.1",
     "lodash": "^3.10.1"
   },
@@ -38,6 +39,7 @@
     "eslint-plugin-filenames": "^0.1.2",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",
+    "mock-fs": "^3.6.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   }

--- a/test/server/fixtures/basic/README.md
+++ b/test/server/fixtures/basic/README.md
@@ -1,3 +1,0 @@
-# Basic Tests
-
-These files are to test out basic interpolation for file name and contents.

--- a/test/server/fixtures/basic/src/index.js
+++ b/test/server/fixtures/basic/src/index.js
@@ -1,3 +1,0 @@
-var <%= codeName %> = require("./<%= code %>.js");
-
-module.exports[<%= codeName %>] = <%= codeName %>;

--- a/test/server/fixtures/basic/src/{{code}}.js
+++ b/test/server/fixtures/basic/src/{{code}}.js
@@ -1,3 +1,0 @@
-module.exports = {
-  greeting: "Hello <%= username %>"
-};

--- a/test/server/fixtures/basic/{{text}}.md
+++ b/test/server/fixtures/basic/{{text}}.md
@@ -1,1 +1,0 @@
-<%= username %>'s very own file


### PR DESCRIPTION
* Ingest init/.gitignore and filter out template files on load. Fixes #9
* Switch tests from real files to "mock-fs" files for more flexible testing.
* Add more scenario tests.

/cc @coopy @benbayard @chaseadamsio @exogen @boygirl @zachhale