### PR TITLE
Adds archetype downloads + installation.

### DIFF
--- a/.eslintrc-server-test
+++ b/.eslintrc-server-test
@@ -7,7 +7,6 @@ env:
 
 globals:
   expect: false
-  sandbox: false
 
 rules:
   no-unused-expressions: 0  # Disable for Chai expression assertions.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Formidable Labs
+Copyright (c) 2015-2016 Formidable Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/builder-init.js
+++ b/bin/builder-init.js
@@ -3,35 +3,85 @@
 
 var path = require("path");
 var async = require("async");
+var chalk = require("chalk");
+
 var prompts = require("../lib/prompts");
-var init = require(path.resolve(__dirname, "../../builder-react-component/init.js"));
 var Templates = require("../lib/templates");
+var Task = require("../lib/task");
 
-// TODO: REMOVE AND IMPLEMENT INSTALL FROM ARCHETYPE
-// https://github.com/FormidableLabs/builder-init/issues/2
-async.auto({
-  "prompts": prompts.bind(null, init),
+/**
+ * Script runner
+ *
+ * @param {Object}    opts       Options object for Task.
+ * @param {Array}     opts.argv  Arguments array (Default: `process.argv`)
+ * @param {Object}    opts.env   Environment object to mutate (Default `process.env`)
+ * @param {Function}  callback   Callback from script run `(err, results)`.
+ * @returns {void}
+ */
+var run = module.exports = function (opts, callback) {
+  var task = new Task(opts);
+  var bin = chalk.green.bold("[builder-init]");
 
-  "templates": ["prompts", function (cb, results) {
-    var data = results.prompts;
-
-    var templates = new Templates({
-      src: path.resolve(__dirname, "../../builder-react-component/init"),
-      dest: path.resolve(process.env.HOME, "Desktop/builder-init-temp"),
-      data: data
-    });
-
-    templates.process(cb);
-  }]
-}, function (err) {
-  // TODO: REAL LOGGING
-  // https://github.com/FormidableLabs/builder-init/issues/4
-  /*eslint-disable no-console*/
-  if (err) {
-    console.error(err);
+  // Help, version, etc. - just call straight up.
+  if (!task.isInit()) {
+    return task.execute(callback);
   }
-  /*eslint-enable no-console*/
 
-  /*eslint-disable no-process-exit*/
-  process.exit(err ? err.code || 1 : 0);
-});
+  // Actual initialization.
+  async.auto({
+    download: task.execute.bind(task),
+
+    prompts: ["download", function (cb, results) {
+      process.stdout.write(
+        bin + " Preparing templates for: " + chalk.magenta(task.archName) + "\n"
+      );
+
+      prompts(results.download.init, cb);
+    }],
+
+    templates: ["prompts", function (cb, results) {
+      if (!results.prompts.destination) {
+        return cb(new Error("Destination field missing from prompts"));
+      }
+
+      var templates = new Templates({
+        src: results.download.src,
+        dest: path.resolve(results.prompts.destination),
+        data: results.prompts
+      });
+
+
+      templates.process(function (err, outFiles) {
+        if (err) { return cb(err); }
+
+        process.stdout.write(
+          "\n" + bin + " Wrote files: \n" +
+          (outFiles || []).map(function (obj) {
+            return " - " + chalk.cyan(path.relative(process.cwd(), obj.dest));
+          }).join("\n") + "\n"
+        );
+
+        cb();
+      });
+    }]
+  }, function (err, results) {
+    if (!err) {
+      process.stdout.write(
+        "\n" + bin + " New " + chalk.magenta(task.archName) + " project is ready at: " +
+        chalk.cyan(path.relative(process.cwd(), results.prompts.destination)) + "\n"
+      );
+    }
+
+    callback(err);
+  });
+};
+
+if (require.main === module) {
+  run(null, function (err) {
+    // TODO: REAL LOGGING
+    // https://github.com/FormidableLabs/builder-init/issues/4
+    if (err) { console.error(err); } // eslint-disable-line no-console
+
+    process.exit(err ? err.code || 1 : 0); // eslint-disable-line no-process-exit
+  });
+}

--- a/lib/args.js
+++ b/lib/args.js
@@ -1,3 +1,0 @@
-"use strict";
-
-module.exports = {};

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -1,8 +1,39 @@
 "use strict";
 
+var fs = require("fs");
 var _ = require("lodash");
 var async = require("async");
 var inquirer = require("inquirer");
+
+/**
+ * Default prompts values added to all prompt calls.
+ */
+var DEFAULTS = {
+  destination: {
+    message: "Destination directory to write",
+    validate: function (val) {
+      var done = this.async();
+
+      if (!val) {
+        return done("Must specify a destination directory");
+      }
+
+      fs.stat(val, function (err) {
+        if (err && err.code === "ENOENT") { return done(true); }
+
+        return done("Destination directory must not already exist");
+      });
+    }
+  },
+  derived: {
+    // `.npmignore` and `.gitignore` need to be proxied as a template to avoid
+    //  NPM losing dev files in `init/` when uploading and executing `npm pack`
+    // so we provide them by default here.
+    npmignore: function (data, cb) { cb(null, ".npmignore"); },
+    gitignore: function (data, cb) { cb(null, ".gitignore"); },
+    npmrc: function (data, cb) { cb(null, ".npmrc"); }
+  }
+};
 
 /**
  * Prompt user for input, validate, and add derived fields to final data object.
@@ -27,20 +58,62 @@ module.exports = function (init, callback) {
     return _.extend({ name: key }, val);
   });
 
+  // Add in special `destination` prompt field if not provided by `init.js`
+  if (!_.contains(prompts, { name: "destination" })) {
+    prompts.push(_.merge({ name: "destination" }, DEFAULTS.destination, init.destination));
+  }
+
+  // Prompt overrides to skip actual user input.
+  var overrides;
+  if (init.overrides) {
+    try {
+      overrides = module.exports._parseOverrides(init.overrides);
+    } catch (err) {
+      return callback(new Error("Prompt overrides loading failed with: " + err.message));
+    }
+  }
+
   // Execute prompts, then derive final data.
   async.auto({
     prompts: function (cb) {
+      // Allow `--prompts=JSON_STRING` overrides.
+      if (overrides) { return cb(null, overrides); }
+
       // Get user prompts. No error, because will prompt user for new input.
       inquirer.prompt(prompts, function (data) { cb(null, data); });
     },
     derived: ["prompts", function (cb, results) {
       // Create object of functions bound to user input data and invoke.
-      async.auto(_.mapValues(init.derived, function (transform) {
-        return transform.bind(null, results.prompts);
-      }), cb);
+      var derived = _({})
+        .extend(DEFAULTS.derived, init.derived)
+        .mapValues(function (fn) { return fn.bind(null, results.prompts); })
+        .value();
+
+      async.auto(derived, cb);
     }]
   }, function (err, results) {
     var data = results ? _.extend({}, results.prompts, results.derived) : null;
     callback(err, data);
   });
 };
+
+/**
+ * Parse overrides string into object.
+ *
+ * Also handles a few scenarios like surrounding single / double quotes.
+ *
+ * @param   {String} str  JSON string
+ * @returns {Object}      JS object
+ */
+module.exports._parseOverrides = function (str) {
+  // Remove quotes.
+  str = str
+    .trim()
+    .replace(/^"{(.*)}"$/, "{$1}")
+    .replace(/^'{(.*)}'$/, "{$1}");
+
+  return JSON.parse(str);
+};
+
+// Expose helpers for testing.
+module.exports._DEFAULTS = DEFAULTS;

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,0 +1,254 @@
+"use strict";
+
+var childProc = require("child_process");
+var path = require("path");
+var zlib = require("zlib");
+var _ = require("lodash");
+var fs = require("fs-extra");
+var async = require("async");
+var chalk = require("chalk");
+var nopt = require("nopt");
+var tar = require("tar");
+var temp = require("temp").track(); // track: Clean up all files on process exit.
+var pkg = require("../package.json");
+
+var OPTIONS = {
+  "help": Boolean,
+  "version": Boolean,
+  "prompts": String
+};
+
+var SHORT_OPTIONS = {
+  "h": ["--help"],
+  "v": ["--version"]
+};
+
+/**
+ * Task wrapper.
+ *
+ * @param {Object} opts         Options object
+ * @param {Array}  opts.argv    Arguments array (Default: `process.argv`)
+ * @param {Object} opts.env     Environment object to mutate (Default `process.env`)
+ * @returns {void}
+ */
+var Task = module.exports = function (opts) {
+  opts = opts || {};
+  this.env = opts.env || process.env;
+
+  // Parse args.
+  var argv = opts.argv || process.argv;
+  var parsed = nopt(OPTIONS, SHORT_OPTIONS, argv);
+  this.promptsOverrides = (parsed.prompts || "").trim();
+  this.archetypes = parsed.argv.remain;
+
+  // Decide task.
+  this.task = this.init;
+  if (parsed.version) {
+    this.task = this.version;
+  } else if (parsed.help || this.archetypes.length === 0) {
+    this.task = this.help;
+  }
+};
+
+/**
+ * Selected task _is_ initialize.
+ *
+ * @returns {Boolean} `true` if initialize task
+ */
+Task.prototype.isInit = function () {
+  return this.task === this.init;
+};
+
+/**
+ * Help.
+ *
+ * ```sh
+ * $ builder-init [-h|--help]
+ * ```
+ *
+ * @param   {Function} callback   Callback function `(err)`
+ * @returns {void}
+ */
+Task.prototype.help = function (callback) {
+  var flags = Object.keys(OPTIONS).map(function (key) {
+    return "  --" + chalk.cyan(key);
+  }).join("\n");
+
+  process.stdout.write(
+    chalk.green.bold("Usage") + ": \n\n  builder-init [flags] <archetype>" +
+    "\n\n" + chalk.green.bold("Flags") + ": \n\n" + flags +
+    "\n\n" + chalk.green.bold("Examples") + ": \n\n" +
+    "`builder-init` can install templates from any source that `npm` can, e.g.:\n\n" +
+    [
+      ["(npm)   ", "builder-react-component"],
+      ["(npm)   ", "builder-react-component@0.2.0"],
+      ["(github)", "FormidableLabs/builder-react-component"],
+      ["(github)", "FormidableLabs/builder-react-component#v0.2.0"],
+      ["(git)   ", "git+ssh://git@github.com:FormidableLabs/builder-react-component.git"],
+      ["(git)   ", "git+ssh://git@github.com:FormidableLabs/builder-react-component.git#v0.2.0"],
+      ["(file)  ", "/FULL/PATH/TO/builder-react-component"]
+    ].map(function (pairs) {
+      return "  " + chalk.red(pairs[0]) + " builder-init " + chalk.cyan(pairs[1]);
+    }).join("\n") + "\n\n"
+  );
+
+  callback();
+};
+
+/**
+ * Version.
+ *
+ * ```sh
+ * $ builder-init [-v|--version]
+ * ```
+ *
+ * @param   {Function} callback   Callback function `(err)`
+ * @returns {void}
+ */
+Task.prototype.version = function (callback) {
+  process.stdout.write(pkg.version + "\n");
+  callback();
+};
+
+// Expose extracted event for testing.
+Task.prototype._onExtracted = function (callback) {
+  return callback;
+};
+
+// Expose `require()` for testing.
+Task.prototype._lazyRequire = function (mod) {
+  return require(mod); // eslint-disable-line global-require
+};
+
+/**
+ * Download an archetype and expand it for templating use.
+ *
+ * ```sh
+ * $ builder-init <archetype>
+ * ```
+ *
+ * @param   {Function} callback   Callback function `(err, { init: OBJ, src: DIR_PATH })`
+ * @returns {void}
+ */
+Task.prototype.init = function (callback) {
+  // Validation.
+  if (this.archetypes.length !== 1) {
+    return callback(new Error(
+      "Must specify exactly 1 archetype to install. Found " + this.archetypes.length +
+      " archetypes: " + this.archetypes.join(", ")));
+  }
+
+  var self = this;
+  self.archetype = self.archetypes[0];
+  self.archName = path.basename(self.archetype);
+
+  // Create a temporary directory to stash the gzip file, unzip it and return
+  // the paths for use in template ingestion.
+  async.auto({
+    tmpDir: temp.mkdir.bind(temp, "builder-init"),
+
+    npmPack: ["tmpDir", function (cb, results) {
+      cb = _.once(cb);
+
+      // Use `npm pack MODULE` to do the dirty work of installing off of file, npm
+      // git, github, etc.
+      //
+      // See: https://docs.npmjs.com/cli/pack
+      var proc = childProc.spawn("npm", ["pack", self.archetype], {
+        cwd: results.tmpDir,
+        env: self.env,
+        stdio: "inherit"
+      });
+      proc.on("error", cb);
+      proc.on("close", function (code) {
+        cb(code === 0 ? null : new Error(
+          "'npm pack " + self.archetype + "' exited with error code: " + code));
+      });
+    }],
+
+    gzFilePath: ["npmPack", function (cb, results) {
+      fs.readdir(results.tmpDir, function (err, files) {
+        if (err) { return cb(err); }
+
+        if (files.length !== 1) {
+          return cb(new Error("Should have exactly 1 downloaded file. Found: " + files.join(", ")));
+        }
+
+        var file = files[0];
+        if (!/\.tgz$/.test(file)) {
+          return cb(new Error("File should have tgz suffix. Found: " + file));
+        }
+
+        cb(null, path.resolve(results.tmpDir, file));
+      });
+    }],
+
+    extracted: ["gzFilePath", function (cb, results) {
+      // Ensure called once, and adds our extracted hook.
+      cb = _.once(self._onExtracted(cb));
+
+      var extractedDir = path.resolve(results.tmpDir, "extracted");
+
+      fs.createReadStream(results.gzFilePath)
+        .pipe(zlib.createUnzip())
+        .pipe(new tar.Extract({
+          path: extractedDir,
+          strip: 1 // Get rid of `<archetype-name>/` level of directory
+        }))
+        .on("error", cb)
+        .on("close", cb.bind(null, null, extractedDir));
+    }],
+
+    init: ["extracted", function (cb, results) {
+      var initPath = path.resolve(results.tmpDir, "extracted/init.js");
+      var init;
+
+      try {
+        init = self._lazyRequire(initPath);
+        if (self.promptsOverrides) {
+          _.extend(init, { overrides: self.promptsOverrides });
+        }
+
+        return cb(null, init);
+
+      } catch (err) {
+        // Allow missing `init.js`
+        if (err.code === "MODULE_NOT_FOUND") { return cb(); }
+
+        return cb(err);
+      }
+    }],
+
+    checkTemplates: ["extracted", function (cb, results) {
+      var templatesPath = path.resolve(results.tmpDir, "extracted/init");
+      fs.stat(templatesPath, function (err, stats) {
+        if (err) {
+          if (err.code === "ENOENT") {
+            return cb(new Error("Archetype '" + self.archName + "/init' directory not found"));
+          }
+
+          return cb(err);
+        }
+
+        if (!stats.isDirectory()) {
+          return cb(new Error(
+            "Archetype '" + self.archName + "/init' exists, but is not a directory"));
+        }
+
+        cb();
+      });
+    }]
+
+  }, function (err, results) {
+    if (err) { return callback(err); }
+
+    callback(null, {
+      init: results.init || {},
+      src: path.resolve(results.tmpDir, "extracted/init")
+    });
+  });
+};
+
+Task.prototype.execute = function (callback) {
+  this.task(callback);
+};

--- a/lib/templates.js
+++ b/lib/templates.js
@@ -109,8 +109,8 @@ Templates.prototype.readTemplate = function (opts, callback) {
  * @returns {Object}                Processed data object
  */
 Templates.prototype.processTemplate = function (opts) {
-  // File path: Bespoke {{}} parsing
-  var dest = this.resolveFilename(opts.dest, this.data);
+  // Resolved _destination_ path with bespoke {{}} parsing
+  var dest = this.resolveFilename(opts.dest);
 
   // Content: Lodash template
   var compiled = _.template(opts.content.toString());
@@ -178,6 +178,15 @@ Templates.prototype.load = function (callback) {
         .on("data", function (item) {
           if (item.stats.isFile()) {
             // Only track real files (we'll `mkdir -p` when creating).
+
+            // Mutate item to add resolved _source_ filename.
+            try {
+              item.resolvedPath = path.resolve(self.resolveFilename(item.path));
+            } catch (err) {
+              return cb(err);
+            }
+
+            // Add to internal list.
             tmpls.push(item);
           } else if (!item.stats.isDirectory()) {
             // Validation: We only handle real files / directories for now.
@@ -196,14 +205,18 @@ Templates.prototype.load = function (callback) {
     // ------------------------------------------------------------------------
     // Ingest ignore file and filter.
     // ------------------------------------------------------------------------
-    loadIgnore: function (cb) {
-      fs.readFile(path.join(self.src, ".gitignore"), function (err, data) {
-        // Process error to allow "not found".
-        err = (err || {}).code === "ENOENT" ? null : err;
-
-        cb(err, data);
+    loadIgnore: ["walkTemplates", function (cb, results) {
+      // Find if there is a `.gitignore` in the source templates.
+      var ignoreFile = _.find(results.walkTemplates, {
+        resolvedPath: path.resolve(self.src, ".gitignore")
       });
-    },
+
+      // Allow non-existent gitignore.
+      if (!ignoreFile) { return cb(); }
+
+      // Read source gitignore from templated or real filename.
+      fs.readFile(ignoreFile.path, cb);
+    }],
 
     filterTemplates: ["walkTemplates", "loadIgnore", function (cb, results) {
       // Get ignore filter (if any).

--- a/package.json
+++ b/package.json
@@ -26,10 +26,14 @@
   },
   "dependencies": {
     "async": "^1.5.0",
+    "chalk": "^1.1.1",
     "fs-extra": "^0.26.3",
     "gitignore-parser": "0.0.2",
     "inquirer": "^0.11.1",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "nopt": "^3.0.6",
+    "tar": "^2.2.1",
+    "temp": "^0.8.3"
   },
   "devDependencies": {
     "chai": "^3.4.1",
@@ -37,6 +41,7 @@
     "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
     "eslint-plugin-filenames": "^0.1.2",
+    "eval": "^0.1.1",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",
     "mock-fs": "^3.6.0",

--- a/test/server/setup.js
+++ b/test/server/setup.js
@@ -3,6 +3,9 @@
 /**
  * Test setup for server-side tests.
  */
+// Start the mock import _first_ to inject mocks into everything.
+require("mock-fs");
+
 var chai = require("chai");
 var sinonChai = require("sinon-chai");
 

--- a/test/server/spec/base.spec.js
+++ b/test/server/spec/base.spec.js
@@ -8,19 +8,64 @@
  * **Note**: Because there is a global sandbox server unit tests should always
  * be run in a separate process from other types of tests.
  */
+var _ = require("lodash");
+var mockFs = require("mock-fs");
+var fs = require("fs-extra");
+var async = require("async");
 var sinon = require("sinon");
+var prompts = require("../../../lib/prompts");
 
-before(function () {
+// ----------------------------------------------------------------------------
+// Base helpers.
+// ----------------------------------------------------------------------------
+var base = module.exports = {
+  // Generic test helpers.
+  sandbox: null,
+  mockFs: null,
+
+  // File stuff
+  // NOTE: Sync methods are OK here because mocked and in-memory.
+  fileRead: function (filePath) {
+    return fs.readFileSync(filePath).toString();
+  },
+  fileExists: function (filePath) {
+    return fs.existsSync(filePath);
+  },
+
+  // Prompts helpers.
+  PROMPT_DEFAULTS: null,
+  addPromptDefaults: function (data) {
+    return _.extend({}, base.PROMPT_DEFAULTS, data);
+  }
+};
+
+// ----------------------------------------------------------------------------
+// Global Setup / Teardown
+// ----------------------------------------------------------------------------
+before(function (done) {
   // Set test environment
   process.env.NODE_ENV = process.env.NODE_ENV || "test";
+
+  var derived = _.mapValues(prompts._DEFAULTS.derived, function (fn) {
+    return fn.bind(null, {});
+  });
+
+  // Async resolve defaults for all tests here.
+  async.auto(derived, function (err, results) {
+    // Hard-code in "destination" for test-sensible-default.
+    base.PROMPT_DEFAULTS = _.extend({ destination: "destination" }, results);
+    done(err);
+  });
 });
 
 beforeEach(function () {
-  global.sandbox = sinon.sandbox.create({
+  base.mockFs = mockFs;
+  base.sandbox = sinon.sandbox.create({
     useFakeTimers: true
   });
 });
 
 afterEach(function () {
-  global.sandbox.restore();
+  base.mockFs.restore();
+  base.sandbox.restore();
 });

--- a/test/server/spec/bin/builder-init.spec.js
+++ b/test/server/spec/bin/builder-init.spec.js
@@ -1,0 +1,411 @@
+"use strict";
+
+/**
+ * These are _almost_ functional tests as we're basically invoking the entire
+ * application, just:
+ *
+ * - Mocking filesystem
+ * - Stubbing stdin to return canned responses to prompts
+ */
+var childProc = require("child_process");
+var crypto = require("crypto");
+var zlib = require("zlib");
+var stream = require("stream");
+var temp = require("temp").track();
+var _ = require("lodash");
+var Prompt = require("inquirer/lib/prompts/base");
+var _eval = require("eval");
+
+var run = require("../../../../bin/builder-init");
+var Task = require("../../../../lib/task");
+var pkg = require("../../../../package.json");
+
+var base = require("../base.spec");
+
+// Helpers
+// **Note**: It would be great to just stub stderr, stdout in beforeEach,
+// but then we don't get test output. So, we manually stub with this wrapper.
+var stdioWrap = function (fn) {
+  return function (done) {
+    base.sandbox.stub(process.stdout, "write");
+
+    var _done = function (err) {
+      process.stdout.write.restore();
+      done(err);
+    };
+
+    try {
+      return fn(_done);
+    } catch (err) {
+      return _done(err);
+    }
+  };
+};
+
+// Mock key I/O parts of the flow.
+/*eslint-disable max-statements*/
+var mockFlow = function (extracted, root) {
+  // Returned object.
+  var stubs = {};
+
+  // Fake filesystem for before and after (stubbed) extraction.
+  var hash = crypto.randomBytes(10).toString("hex");
+  var tmpDir = "tmp-dir-" + hash;
+  var fsObj = _.extend({}, root);
+  fsObj[tmpDir] = {
+    "mock-archetype-0.0.1.tgz": ""
+  };
+
+  var extractedObj = _.cloneDeep(fsObj);
+  extractedObj[tmpDir] = _.merge({}, fsObj[tmpDir], extracted ? { extracted: extracted } : null);
+
+  base.mockFs(fsObj);
+
+  // Stub out creating a temp directory with a _known_ name.
+  base.sandbox.stub(temp, "mkdir").yields(null, tmpDir);
+
+  // Immediately call `close` with success exit.
+  stubs.spawnOn = base.sandbox.stub();
+  stubs.spawnOn.withArgs("error").returns();
+  stubs.spawnOn.withArgs("close").yields(0);
+
+  // Override the `npm pack` process to just fail / succeed.
+  stubs.spawn = base.sandbox.stub(childProc, "spawn").returns({
+    on: stubs.spawnOn
+  });
+
+  // Use our special hook to change the filesystem as if we expanded a
+  // real download.
+  base.sandbox.stub(Task.prototype, "_onExtracted", function (callback) {
+    base.mockFs(extractedObj);
+
+    return callback;
+  });
+
+  stubs.prompt = base.sandbox.stub(Prompt.prototype, "run").yields("dest");
+
+  return stubs;
+};
+/*eslint-enable max-statements*/
+
+describe("bin/builder-init", function () {
+
+  beforeEach(function () {
+    // Mock out unzipping.
+    base.sandbox.stub(zlib, "createUnzip").returns(new stream.PassThrough());
+
+    // Node `4`+ can't `require` from the mocked filesystem, so hackily
+    // approximate here.
+    base.sandbox.stub(Task.prototype, "_lazyRequire", function (mod) {
+      try {
+        return require(mod); // eslint-disable-line global-require
+      } catch (err) {
+        if (err.code === "MODULE_NOT_FOUND" && base.fileExists(mod)) {
+          return _eval(base.fileRead(mod));
+        }
+
+        throw err;
+      }
+    });
+  });
+
+  describe("non-init", function () {
+
+    it("displays help on no args", stdioWrap(function (done) {
+      run({ argv: ["node", "builder-init"] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(process.stdout.write).to.be.calledWithMatch("builder-init [flags] <archetype>");
+
+        done();
+      });
+    }));
+
+    it("displays help on -h", stdioWrap(function (done) {
+      run({ argv: ["node", "builder-init", "-h"] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(process.stdout.write).to.be.calledWithMatch("builder-init [flags] <archetype>");
+
+        done();
+      });
+    }));
+
+    it("displays version on -v", stdioWrap(function (done) {
+      run({ argv: ["node", "builder-init", "-v"] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(process.stdout.write).to.be.calledWithMatch(pkg.version);
+
+        done();
+      });
+    }));
+
+  });
+
+  describe("errors", function () {
+
+    it("errors on missing init/ and no init.js", stdioWrap(function (done) {
+      mockFlow({});
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message").that.contains("init' directory not found");
+        done();
+      });
+    }));
+
+    it("errors on missing init/ with init.js", stdioWrap(function (done) {
+      mockFlow({
+        "init.js": "module.exports = {};"
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message").that.contains("init' directory not found");
+        done();
+      });
+    }));
+
+    it("errors on init/ not a directory", stdioWrap(function (done) {
+      mockFlow({
+        "init": "file, not a directory"
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message").that.contains("exists, but is not a directory");
+        done();
+      });
+    }));
+
+    it("errors when destination already exists", stdioWrap(function (done) {
+      mockFlow({
+        "init": {}
+      }, {
+        "dest": {} // Will collide with default destination.
+      });
+
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message").that.contains("dest already exists");
+        done();
+      });
+    }));
+
+    it("errors on failed npm pack download", stdioWrap(function (done) {
+      var stubs = mockFlow({
+        "init": {}
+      });
+
+      // Fake npm pack download error.
+      stubs.spawnOn.reset();
+      stubs.spawnOn.withArgs("error").returns();
+      stubs.spawnOn.withArgs("close").yields(1);
+
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message").that.contains("exited with error code: 1");
+        done();
+      });
+    }));
+
+    it("errors on invalid --prompts data", stdioWrap(function (done) {
+      mockFlow({
+        "init.js": "module.exports = " + JSON.stringify({
+          prompts: {
+            name: { message: "a name" }
+          }
+        }) + ";",
+        "init": {
+          "{{name}}.txt": "A <%= name %>."
+        }
+      });
+      run({ argv: ["node", "builder-init", "archetype", "--prompts=INVALID"] }, function (err) {
+        expect(err).to.have.property("message").that.contains("Prompt overrides loading failed");
+        done();
+      });
+    }));
+
+  });
+
+  describe(".npmignore and .gitignore complexities", function () {
+
+    it("errors on .npmignore collision", stdioWrap(function (done) {
+      mockFlow({
+        "init": {
+          ".npmignore": "",
+          "{{npmignore}}": ""
+        }
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("Encountered 1 file path conflict").and
+          .that.contains("npmignore");
+
+        done();
+      });
+    }));
+
+    it("errors on .gitignore collision", stdioWrap(function (done) {
+      mockFlow({
+        "init": {
+          ".gitignore": "",
+          "{{gitignore}}": ""
+        }
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("Encountered 1 file path conflict").and
+          .that.contains("gitignore");
+
+        done();
+      });
+    }));
+
+    it("errors on .gitignore and .npmignore collisions", stdioWrap(function (done) {
+      mockFlow({
+        "init": {
+          ".gitignore": "",
+          "{{gitignore}}": "",
+          ".npmignore": "",
+          "{{npmignore}}": ""
+        }
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("Encountered 2 file path conflicts").and
+          .that.contains("gitignore").and
+          .that.contains("npmignore");
+
+        done();
+      });
+    }));
+
+    it("expands .gitignore and excludes ignored files", stdioWrap(function (done) {
+      var stubs = mockFlow({
+        "init.js": "module.exports = " + JSON.stringify({
+          prompts: {
+            fileName: { message: "a file name" },
+            varName: { message: "a variable name" }
+          }
+        }) + ";",
+        "init": {
+          "{{gitignore}}": "coverage",
+          "coverage": {
+            "a-file": "shouldn't be copied"
+          },
+          "{{fileName}}.js": "module.exports = { <%= varName %>: 'foo' };"
+        }
+      });
+
+      // Note: These have to match prompt fields + `destination` in order.
+      stubs.prompt
+        .reset()
+        .onCall(0).yields("file-name")
+        .onCall(1).yields("myCoolVar")
+        .onCall(2).yields("dest");
+
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(base.fileRead("dest/.gitignore")).to.contain("coverage");
+        expect(base.fileRead("dest/file-name.js")).to.contain("myCoolVar: 'foo'");
+        expect(base.fileExists("dest/coverage/a-file")).to.be.false;
+
+        done();
+      });
+    }));
+
+  });
+
+  describe("basic", function () {
+
+    it("allows no init.js and empty init/", stdioWrap(function (done) {
+      mockFlow({
+        "init": {}
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, done);
+    }));
+
+    it("allows no init.js with init/", stdioWrap(function (done) {
+      mockFlow({
+        "init": {
+          "foo.js": "module.exports = { foo: 42 };"
+        }
+      });
+
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(base.fileRead("dest/foo.js")).to.contain("foo: 42");
+
+        done();
+      });
+    }));
+
+    it("initializes a basic project", stdioWrap(function (done) {
+      var stubs = mockFlow({
+        "init.js": "module.exports = " + JSON.stringify({
+          prompts: {
+            fileName: { message: "a file name" },
+            varName: { message: "a variable name" }
+          }
+        }) + ";",
+        "init": {
+          "{{npmignore}}": "coverage",
+          "{{gitignore}}": "coverage",
+          "README.md": "My readme",
+          "{{fileName}}.js": "module.exports = { <%= varName %>: 'foo' };",
+          "test": {
+            "client": {
+              "spec": {
+                "{{fileName}}.spec.js": "describe('<%= fileName %>');"
+              }
+            }
+          }
+        }
+      });
+
+      // Note: These have to match prompt fields + `destination` in order.
+      stubs.prompt
+        .reset()
+        .onCall(0).yields("file-name")
+        .onCall(1).yields("myCoolVar")
+        .onCall(2).yields("dest");
+
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(base.fileRead("dest/.npmignore")).to.contain("coverage");
+        expect(base.fileRead("dest/.gitignore")).to.contain("coverage");
+        expect(base.fileRead("dest/README.md")).to.contain("My readme");
+        expect(base.fileRead("dest/file-name.js")).to.contain("myCoolVar: 'foo'");
+        expect(base.fileRead("dest/test/client/spec/file-name.spec.js"))
+          .to.contain("describe('file-name');");
+
+        done();
+      });
+    }));
+
+    it("handles --prompts data", stdioWrap(function (done) {
+      mockFlow({
+        "init.js": "module.exports = " + JSON.stringify({
+          prompts: {
+            name: { message: "a name" }
+          }
+        }) + ";",
+        "init": {
+          "{{name}}.txt": "A <%= _.capitalize(name) %>."
+        }
+      });
+
+      var prompts = "--prompts='" + JSON.stringify({
+        name: "chester",
+        destination: "dest"
+      }) + "'";
+
+      run({ argv: ["node", "builder-init", "archetype", prompts] }, function (err) {
+        if (err) { return done(err); }
+
+        expect(base.fileRead("dest/chester.txt")).to.contain("A Chester.");
+
+        done();
+      });
+    }));
+
+  });
+
+});

--- a/test/server/spec/lib/task.spec.js
+++ b/test/server/spec/lib/task.spec.js
@@ -1,0 +1,102 @@
+"use strict";
+
+var Task = require("../../../../lib/task");
+var pkg = require("../../../../package.json");
+var base = require("../base.spec");
+
+describe("lib/task", function () {
+
+  describe("#execute", function () {
+
+    it("selects help", function (done) {
+      base.sandbox.stub(Task.prototype, "help").yields();
+      var task = new Task({ argv: ["node", "builder-init", "-h"] });
+      task.execute(function () {
+        expect(task.isInit()).to.be.false;
+        expect(task.help).to.be.calledOnce;
+        done();
+      });
+    });
+
+    it("selects version", function (done) {
+      base.sandbox.stub(Task.prototype, "version").yields();
+      var task = new Task({ argv: ["node", "builder-init", "--version"] });
+      task.execute(function () {
+        expect(task.isInit()).to.be.false;
+        expect(task.version).to.be.calledOnce;
+        done();
+      });
+    });
+
+    it("selects init", function (done) {
+      base.sandbox.stub(Task.prototype, "init").yields();
+      var task = new Task({ argv: ["node", "builder-init", "foo-archetype"] });
+      task.execute(function () {
+        expect(task.isInit()).to.be.true;
+        expect(task.init).to.be.calledOnce;
+        done();
+      });
+    });
+
+  });
+
+  describe("#help", function () {
+
+    it("displays help", function (done) {
+      base.sandbox.stub(process.stdout, "write");
+      base.sandbox.spy(Task.prototype, "help");
+      var task = new Task({ argv: ["node", "builder-init", "--help"] });
+      task.execute(function (err) {
+        if (err) { return done(err); }
+        expect(task.help).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledOnce.and
+          .to.be.calledWithMatch("builder-init [flags] <archetype>");
+
+        done();
+      });
+    });
+
+  });
+
+  describe("#version", function () {
+
+    it("displays version", function (done) {
+      base.sandbox.stub(process.stdout, "write");
+      base.sandbox.spy(Task.prototype, "version");
+      var task = new Task({ argv: ["node", "builder-init", "-v"] });
+      task.execute(function (err) {
+        if (err) { return done(err); }
+        expect(task.version).to.be.calledOnce;
+        expect(process.stdout.write)
+          .to.be.calledOnce.and
+          .to.be.calledWithMatch(pkg.version);
+
+        done();
+      });
+    });
+
+  });
+
+  describe("#init", function () {
+
+    it("displys help if no archetype specified", function (done) {
+      base.sandbox.stub(Task.prototype, "help").yields();
+      var task = new Task({ argv: ["node", "builder-init"] });
+      task.execute(function () {
+        expect(task.isInit()).to.be.false;
+        expect(task.help).to.be.calledOnce;
+        done();
+      });
+    });
+
+    it("fails if 2 archetypes specified", function (done) {
+      var task = new Task({ argv: ["node", "builder-init", "one", "two"] });
+      task.execute(function (err) {
+        expect(err).to.have.property("message").to.contain("Found 2 archetypes");
+        done();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
At long last, `builder-init` is (hopefully) ready for prime time!
### Overview

We use a process spawn of `npm pack` to do the heavy lifting for downloading
archetype tarballs from file, npm, git, etc. We then expand the tarballs in
a temp directory and process them into an outputted project.
- Downloads + installs archetype templates from npm, git, file, etc. Fixes #2
- Adds `builder-init --help`. Fixes #5
- Adds `builder-init --version`.
- Adds `builder-init <archetype> --prompts=JSON` helper for automation.
- Adds usage / documenation. Fixes #6
- Add near-functional tests for most full user interaction flows.
### Kicking the Tires

This should work:

``` sh
$ builder-init FormidableLabs/builder-react-component#chore-init-install
```

from the parallel PR https://github.com/FormidableLabs/builder-react-component/pull/33
### Usage

```
$ builder-init -h
Usage:

  builder-init [flags] <archetype>

Flags:

  --help
  --version

Examples: 

`builder-init` can install templates from any source that `npm` can, e.g.:

  (npm)    builder-init builder-react-component
  (npm)    builder-init builder-react-component@0.2.0
  (github) builder-init FormidableLabs/builder-react-component
  (github) builder-init FormidableLabs/builder-react-component#v0.2.0
  (git)    builder-init git+ssh://git@github.com:FormidableLabs/builder-react-component.git
  (git)    builder-init git+ssh://git@github.com:FormidableLabs/builder-react-component.git#v0.2.0
  (file)   builder-init /FULL/PATH/TO/builder-react-component
```
### Sample Flow

```
$ builder-init FormidableLabs/builder-react-component#chore-init-install
builder-react-component-0.1.4.tgz
[builder-init] Preparing templates for: builder-react-component
? Package / GitHub project name (e.g., 'whiz-bang-component') green-button
? GitHub organization name (e.g., 'AcmeCorp') GreenCorp
? Package description The Green Button!
? License date 2016
? License organization (e.g., you or your company) GreenCorp
? Destination directory to write green-button

[builder-init] Wrote files:
 - green-button/.babelrc
 - green-button/.builderrc
 - green-button/.editorconfig
 - green-button/.travis.yml
 - green-button/CONTRIBUTING.md
 - green-button/LICENSE.txt
 - green-button/README.md
 - green-button/package.json
 - green-button/.gitignore
 - green-button/.npmignore
 - green-button/demo/app.jsx
 - green-button/demo/index.html
 - green-button/src/index.js
 - green-button/src/components/green-button.jsx
 - green-button/test/client/main.js
 - green-button/test/client/test.html
 - green-button/test/client/spec/components/green-button.spec.jsx

[builder-init] New builder-react-component project is ready at: green-button
```
### Review

Admittedly, this PR is a biggie, so appreciate any review we can get here.
However, the bulk of the line changes are in the tests, and we've now got
pretty comprehensive coverage of some awkward corner cases that can arise.

/cc @coopy @benbayard @chaseadamsio @exogen @boygirl @zachhale @kenwheeler @jstrimpel @baer 
