### PR TITLE
Log error message and process stack trace on error

### DIFF
--- a/bin/builder-init.js
+++ b/bin/builder-init.js
@@ -10,6 +10,15 @@ var prompts = require("../lib/prompts");
 var Templates = require("../lib/templates");
 var Task = require("../lib/task");
 
+// TODO: REAL LOGGING
+// https://github.com/FormidableLabs/builder-init/issues/4
+/* eslint-disable no-console */
+var logError = function (err) {
+  // Print the error with stack trace if available
+  console.error(err.stack || err);
+};
+/* eslint-enable no-console */
+
 /**
  * Script runner
  *
@@ -80,9 +89,7 @@ var run = module.exports = function (opts, callback) {
 
 if (require.main === module) {
   run(null, function (err) {
-    // TODO: REAL LOGGING
-    // https://github.com/FormidableLabs/builder-init/issues/4
-    if (err) { console.error(err); } // eslint-disable-line no-console
+    if (err) { logError(err); }
 
     process.exit(err ? err.code || 1 : 0); // eslint-disable-line no-process-exit
   });


### PR DESCRIPTION
This helps provide more context for the source of errors when debugging generating projects from archetypes.

**Before:**
```
[SyntaxError: Unexpected token ;]
```

**After:**
```
SyntaxError: Unexpected token ;

Process stack trace:
Trace
    at logError (/Users/per/dev/formidable/builder/builder-init/bin/builder-init.js:19:11)
    at /Users/per/dev/formidable/builder/builder-init/bin/builder-init.js:93:16
    at /Users/per/dev/formidable/builder/builder-init/bin/builder-init.js:87:5
    at /Users/per/dev/formidable/builder/builder-init/node_modules/async/lib/async.js:52:16
    at /Users/per/dev/formidable/builder/builder-init/node_modules/async/lib/async.js:570:21
    at /Users/per/dev/formidable/builder/builder-init/node_modules/async/lib/async.js:167:37
    at /Users/per/dev/formidable/builder/builder-init/lib/task.js:259:23
    at /Users/per/dev/formidable/builder/builder-init/node_modules/async/lib/async.js:52:16
    at /Users/per/dev/formidable/builder/builder-init/node_modules/async/lib/async.js:570:21
    at /Users/per/dev/formidable/builder/builder-init/node_modules/async/lib/async.js:167:37
```