### PR TITLE
Capture full stack traces and add init.js errors.

### DIFF
--- a/bin/builder-init.js
+++ b/bin/builder-init.js
@@ -82,7 +82,10 @@ if (require.main === module) {
   run(null, function (err) {
     // TODO: REAL LOGGING
     // https://github.com/FormidableLabs/builder-init/issues/4
-    if (err) { console.error(err); } // eslint-disable-line no-console
+    if (err) {
+      // Try to get full stack, then full string if not.
+      console.error(err.stack || err.toString()); // eslint-disable-line no-console
+    }
 
     process.exit(err ? err.code || 1 : 0); // eslint-disable-line no-process-exit
   });

--- a/lib/task.js
+++ b/lib/task.js
@@ -231,6 +231,9 @@ Task.prototype.init = function (callback) {
         // Allow missing `init.js`
         if (err.code === "MODULE_NOT_FOUND") { return cb(); }
 
+        // Enhance error message.
+        err.message += "\n[builder-init] Error while importing '" + self.archName + "/init.js'";
+
         return cb(err);
       }
     }],

--- a/test/server/spec/bin/builder-init.spec.js
+++ b/test/server/spec/bin/builder-init.spec.js
@@ -226,6 +226,21 @@ describe("bin/builder-init", function () {
       });
     }));
 
+    it("errors on invalid init.js", stdioWrap(function (done) {
+      mockFlow({
+        "init.js": "BAD_CODE {",
+        "init": {
+          "{{name}}.txt": "A <%= name %>."
+        }
+      });
+      run({ argv: ["node", "builder-init", "mock-archetype"] }, function (err) {
+        expect(err).to.have.property("message")
+          .that.contains("[builder-init] Error while importing 'mock-archetype/init.js'").and
+          .that.contains("Unexpected token {");
+
+        done();
+      });
+    }));
   });
 
   describe(".npmignore and .gitignore complexities", function () {


### PR DESCRIPTION
An alternate approach to https://github.com/FormidableLabs/builder-init/pull/24

This captures stacks from _anything_ that throws at a more granular level.

For example, @paulathevalley 's syntax error in `init.js` now points us to the `_lazyRequire()` import function specifically within the `async.auto.init` workflow function, and I've added an extra `message` adjustment to help a bit more so we get:

```sh
$ builder-init $(pwd)/temp-archetype/
temp-archetype-1.0.0.tgz
SyntaxError: Unexpected token }
[builder-init] Error when importing 'temp-archetype/init.js'
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:414:25)
    at Object.Module._extensions..js (module.js:442:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Task._lazyRequire (/Users/rroemer/scm/fmd/builder-init/lib/task.js:120:10)
    at Array.async.auto.init (/Users/rroemer/scm/fmd/builder-init/lib/task.js:223:21)
    at listener (/Users/rroemer/scm/fmd/builder-init/node_modules/async/lib/async.js:605:42)
```

/cc @coopy @paulathevalley 