### PR TITLE
Adjust npm pack spawn for windows. 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,11 @@ History
 * XXX
 -->
 
+## Current
+
+* Make `npm pack` spawn Windows-compatible.
+  [#27](https://github.com/FormidableLabs/builder-init/issues/27)
+
 ## 0.2.1
 
 * Expand full stack traces on errors.

--- a/lib/task.js
+++ b/lib/task.js
@@ -150,11 +150,22 @@ Task.prototype.init = function (callback) {
     npmPack: ["tmpDir", function (cb, results) {
       cb = _.once(cb);
 
+      // Set up command and arguments assuming Linux / Mac.
+      var cmd = "npm";
+      var args = ["pack", self.archetype];
+
+      // Detect and adjust commands if windows.
+      var isWin = /^win/.test(process.platform);
+      if (isWin) {
+        cmd = "cmd";
+        args = ["/c", "npm"].concat(args);
+      }
+
       // Use `npm pack MODULE` to do the dirty work of installing off of file, npm
       // git, github, etc.
       //
       // See: https://docs.npmjs.com/cli/pack
-      var proc = childProc.spawn("npm", ["pack", self.archetype], {
+      var proc = childProc.spawn(cmd, args, {
         cwd: results.tmpDir,
         env: self.env,
         stdio: "inherit"


### PR DESCRIPTION
Ok, this actually seems to be a pretty simple fix. I've manually vetted this against mac and windows. Fixes #27 

@LittleBrainz -- Can you install this branch and confirm it works for you on your Windows machine?

/cc @coopy 

P.S. I've also added #29 to keep Windows CI on our radar.