### PR TITLE
Add support for {{eslintrc}} file template

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ To address this, we have special `derived` values built in by default to
 * `{{gitignore}}` -> `.gitignore`
 * `{{npmignore}}` -> `.npmignore`
 * `{{npmrc}}` -> `.npmrc`
+* `{{eslintrc}}` -> `.eslintrc`
 
 In your archetype `init` directory you should add any / none of these files
 with the following names instead of their real ones:
@@ -307,6 +308,7 @@ init/
   {{gitignore}}
   {{npmignore}}
   {{npmrc}}
+  {{eslintrc}}
 ```
 
 As a side note for your git usage, this now means that `init/.gitignore` doesn't

--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -31,6 +31,7 @@ var DEFAULTS = {
     // so we provide them by default here.
     npmignore: function (data, cb) { cb(null, ".npmignore"); },
     gitignore: function (data, cb) { cb(null, ".gitignore"); },
+    eslintrc: function (data, cb) { cb(null, ".eslintrc"); },
     npmrc: function (data, cb) { cb(null, ".npmrc"); }
   }
 };

--- a/test/server/spec/lib/templates.spec.js
+++ b/test/server/spec/lib/templates.spec.js
@@ -275,6 +275,34 @@ describe("lib/templates", function () {
       });
     });
 
+    describe("eslintrc file", function () {
+      var instance;
+
+      beforeEach(function () {
+        base.mockFs({
+          "src": {
+            "{{eslintrc}}": "---"  // Use token name per our guidelines
+          }
+        });
+
+        instance = new Templates({
+          src: "src",
+          dest: "dest",
+          data: base.addPromptDefaults() // Always get these from prompts
+        });
+        process = instance.process.bind(instance);
+      });
+
+      it("supports .eslintrc file template", function (done) {
+        process(function (err) {
+          if (err) { return done(err); }
+
+          expect(base.fileRead("dest/.eslintrc")).to.equal("---");
+          done();
+        });
+      });
+    });
+
     describe("basic templates", function () {
       var basicTemplates;
 


### PR DESCRIPTION
This is another special case - having a literal `.eslintrc` that uses the `extends` keyword in the `init/` directory doesn't play well with editor lint plugins as the extension file cannot be found in `node_modules`.

cc @ryan-roemer 